### PR TITLE
fix(affichage): Inversion de l'ordre des notes

### DIFF
--- a/carnet-de-bord.js
+++ b/carnet-de-bord.js
@@ -176,7 +176,7 @@ widget.contentTypes = [
                     that.compact = allGrades[0].value
 
                 })
-                that.full = allGrades
+                that.full = allGrades.reverse()
             }
 
         },


### PR DESCRIPTION
Auparavant, les notes récentes s'affichaient de la plus ancienne à la plus récente et cela porte à confusion, notamment quand on affiche la note la plus récente dans "l'overview" du carnet de bord. Ce commit inverse donc l'ordre des notes pour une meilleure expérience utilisateur.